### PR TITLE
Force charset to be utf-8

### DIFF
--- a/src/components/html.js
+++ b/src/components/html.js
@@ -24,6 +24,7 @@ module.exports = ({name, content}) => {
   return (
     <html>
       <head>
+        <meta charSet='utf-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
         <title>{name} - Documentation</title>
         <link href='https://fonts.googleapis.com/css?family=Roboto+Mono:400,500|Roboto:300,500,700' rel='stylesheet' />


### PR DESCRIPTION
Had problems with characters showing up instead of `&nbsp;` and weird encoding in the stylesheets. Setting the charset manually fixes these issues.